### PR TITLE
Dont stop service if package absent

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,6 +38,13 @@
 #
 #   defaults to: `running`
 #
+# [*manage_service*]
+#  `Bool`
+#   
+#   State whether or not this puppet module should manage the service.
+#
+#   defaults to: `true`
+#
 # [*config_file*]
 #   `String`
 #
@@ -101,6 +108,7 @@ class smartd (
   $package_name       = $smartd::params::package_name,
   $service_name       = $smartd::params::service_name,
   $service_ensure     = $smartd::params::service_ensure,
+  $manage_service     = $smartd::params::manage_service,
   $config_file        = $smartd::params::config_file,
   $devicescan         = $smartd::params::devicescan,
   $devicescan_options = $smartd::params::devicescan_options,
@@ -146,14 +154,16 @@ class smartd (
     ensure => $pkg_ensure,
   }
 
-  service { $service_name:
-    ensure     => $svc_ensure,
-    enable     => $svc_enable,
-    hasrestart => true,
-    hasstatus  => true,
-  }
+  if $manage_service {
+    service { $service_name:
+      ensure     => $svc_ensure,
+      enable     => $svc_enable,
+      hasrestart => true,
+      hasstatus  => true,
+    }
 
-  Package[$package_name] -> Service[$service_name]
+    Package[$package_name] -> Service[$service_name]
+  }
 
   file { $config_file:
     ensure  => $file_ensure,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,6 +42,7 @@
 #  `Bool`
 #   
 #   State whether or not this puppet module should manage the service.
+#   This parameter is disregarded when $ensure = absent|purge.
 #
 #   defaults to: `true`
 #
@@ -138,12 +139,14 @@ class smartd (
       $svc_ensure  = $service_ensure
       $svc_enable  = $service_ensure ? { 'running' => true, 'stopped' => false }
       $file_ensure = 'present'
+      $srv_manage  = $manage_service
     }
     'absent', 'purged': {
       $pkg_ensure  = $ensure
       $svc_ensure  = 'stopped'
       $svc_enable  = false
       $file_ensure = 'absent'
+      $srv_manage  = false
     }
     default: {
       fail("unsupported value of \$ensure: ${ensure}")
@@ -154,7 +157,7 @@ class smartd (
     ensure => $pkg_ensure,
   }
 
-  if $manage_service {
+  if $srv_manage {
     service { $service_name:
       ensure     => $svc_ensure,
       enable     => $svc_enable,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,6 +15,7 @@
 class smartd::params {
   $package_name       = 'smartmontools'
   $service_ensure     = 'running'
+  $manage_service     = true
   $devicescan         = true
   $devicescan_options = undef
   $devices            = []


### PR DESCRIPTION
Please merge #3 first.

If the smartd package is not installed, puppet will attempt to stop a service that doesn't exist. 
For this reason, the smartd service should not be manage if `$ensure` is set to `absent` or `purged`.

If smartd is getting uninstalled, the deb script will take care to stop the service anyway.
